### PR TITLE
Support v1.Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ integration-test-base: &integration-test-base
         name: Start minikube
         background: true
         command: |
-          sudo -E minikube start --vm-driver=none --cpus 2 --memory 4096 --kubernetes-version=${K8S_VERSION}
+          sudo -E minikube start --vm-driver=none --cpus 2 --memory 4096 --kubernetes-version=${K8S_VERSION} --extra-config="kubeadm.ignore-preflight-errors=FileExisting-crictl"
 
     - run:
         name: Setup kubectl

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Here at Banzai Cloud we love and write lots of Kubernetes [operators](https://gi
 - ServiceAccount
 - PodDisruptionBudget
 - Unstructured
+- Node
 
 ### How to use it
 

--- a/node.go
+++ b/node.go
@@ -1,0 +1,71 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	v1 "k8s.io/api/core/v1"
+	kubernetescorev1 "k8s.io/kubernetes/pkg/apis/core/v1"
+)
+
+type nodeMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewNodeMatcher(objectMatcher ObjectMatcher) *nodeMatcher {
+	return &nodeMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+func (m nodeMatcher) Match(oldOrig, newOrig *v1.Node) (bool, error) {
+
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	kubernetescorev1.SetObjectDefaults_Node(new)
+
+	type Node struct {
+		ObjectMeta
+		Spec v1.NodeSpec
+	}
+
+	oldData, err := json.Marshal(Node{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+
+	newObject := Node{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/objectmatch.go
+++ b/objectmatch.go
@@ -218,6 +218,16 @@ func (om *objectMatcher) Match(old, new interface{}) (bool, error) {
 			return false, errors.WithStack(err)
 		}
 		return ok, nil
+	case *corev1.Node:
+		oldObject := old.(*corev1.Node)
+		newObject := new.(*corev1.Node)
+
+		m := NewNodeMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
 	}
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #4 
| License         | Apache 2.0

### What's in this PR?
Adds support for matching v1.Node objects.
Also it fixes the circleci build for kubernetes 1.11 by ignoring preflight check for crictl in minikube.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
