### PR TITLE
Rename argument `new` to `newOrig`

### DIFF
--- a/pdb.go
+++ b/pdb.go
@@ -32,31 +32,31 @@ func NewPodDisruptionBudgetMatcher(objectMatcher ObjectMatcher) *podDisruptionBu
 }
 
 // Match compares two autoscalev2beta1.HorizontalPodAutoscaler objects
-func (m podDisruptionBudgetMatcher) Match(old, new *policyv1beta1.PodDisruptionBudget) (bool, error) {
+func (m podDisruptionBudgetMatcher) Match(oldOrig, newOrig *policyv1beta1.PodDisruptionBudget) (bool, error) {
 	type PodDisruptionBudgetMatcher struct {
 		ObjectMeta
 		Spec policyv1beta1.PodDisruptionBudgetSpec
 	}
 
 	oldData, err := json.Marshal(PodDisruptionBudgetMatcher{
-		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
-		Spec:       old.Spec,
+		ObjectMeta: m.objectMatcher.GetObjectMeta(oldOrig.ObjectMeta),
+		Spec:       oldOrig.Spec,
 	})
 	if err != nil {
-		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", oldOrig.Name)
 	}
 	newObject := PodDisruptionBudgetMatcher{
-		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
-		Spec:       new.Spec,
+		ObjectMeta: m.objectMatcher.GetObjectMeta(newOrig.ObjectMeta),
+		Spec:       newOrig.Spec,
 	}
 	newData, err := json.Marshal(newObject)
 	if err != nil {
-		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", newOrig.Name)
 	}
 
 	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
 	if err != nil {
-		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+		return false, emperror.WrapWith(err, "could not match objects", "name", newOrig.Name)
 	}
 
 	return matched, nil


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kind of
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

Renaming of a variable which causes confusion.

### Why?

`new` is a function that Go provides globally this commit removes using it as a variable name.

### Additional context

See other implementations within this codebase where they use alternative names https://github.com/banzaicloud/k8s-objectmatcher/blob/1596e84aae2764cab454a32215e756bbbee3af5d/pvc.go#L36

### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
