### PR TITLE
Remove null fields from current object

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -580,7 +580,7 @@ func TestIntegration(t *testing.T) {
 				n.Spec.PodCIDR = "10.0.0.1/24"
 				// ignore due to already removed field
 			}).withIgnoreVersions([]string{"v1.10"}),
-		NewTestMatch("statefulset diff for volumeclaimtemplates",
+		NewTestMatch("statefulset match for volumeclaimtemplates",
 			&appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{GenerateName: "test-", Namespace: "default"},
 				Spec: appsv1.StatefulSetSpec{
@@ -596,7 +596,9 @@ func TestIntegration(t *testing.T) {
 					},
 					VolumeClaimTemplates: []v1.PersistentVolumeClaim{
 						{
-							ObjectMeta: metav1.ObjectMeta{Name: "vault-raft"},
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "vault-raft",
+							},
 							Spec: v1.PersistentVolumeClaimSpec{
 								AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 								Resources: v1.ResourceRequirements{
@@ -612,9 +614,6 @@ func TestIntegration(t *testing.T) {
 						},
 					},
 				},
-			}).
-			withLocalChange(func(i interface{}) {
-
 			}),
 	}
 	runAll(t, tests)

--- a/main_test.go
+++ b/main_test.go
@@ -385,6 +385,17 @@ func testMatchOnObject(testItem *TestItem) error {
 				log.Printf("Failed to remove object %s", existing.GetName())
 			}
 		}()
+	case *appsv1.StatefulSet:
+		existing, err = testContext.Client.AppsV1().StatefulSets(newObject.GetNamespace()).Create(newObject.(*appsv1.StatefulSet))
+		if err != nil {
+			return emperror.WrapWith(err, "failed to create object", "object", newObject)
+		}
+		defer func() {
+			err = testContext.Client.AppsV1().StatefulSets(newObject.GetNamespace()).Delete(existing.GetName(), deleteOptions)
+			if err != nil {
+				log.Printf("Failed to remove object %s", existing.GetName())
+			}
+		}()
 	}
 
 	if testItem.remoteChange != nil {
@@ -401,11 +412,6 @@ func testMatchOnObject(testItem *TestItem) error {
 	}
 
 	matched := patchResult.IsEmpty()
-
-	//matched, err := New(klogr.New()).Match(existing, newObject)
-	//if err != nil {
-	//	return err
-	//}
 
 	if testItem.shouldMatch && !matched {
 		return emperror.With(errors.New("Objects did not match"), "patch", patchResult)

--- a/patch/patch.go
+++ b/patch/patch.go
@@ -45,7 +45,7 @@ func (p *PatchMaker) Calculate(currentObject, modifiedObject runtime.Object) (*P
 
 	current, _, err = DeleteNullInJson(current)
 	if err != nil {
-		return nil, emperror.Wrap(err, "Failed to delete null from modified object")
+		return nil, emperror.Wrap(err, "Failed to delete null from current object")
 	}
 
 	modified, err := json.Marshal(modifiedObject)

--- a/patch/patch.go
+++ b/patch/patch.go
@@ -43,6 +43,11 @@ func (p *PatchMaker) Calculate(currentObject, modifiedObject runtime.Object) (*P
 		return nil, emperror.Wrap(err, "Failed to convert current object to byte sequence")
 	}
 
+	current, _, err = DeleteNullInJson(current)
+	if err != nil {
+		return nil, emperror.Wrap(err, "Failed to delete null from modified object")
+	}
+
 	modified, err := json.Marshal(modifiedObject)
 	if err != nil {
 		return nil, emperror.Wrap(err, "Failed to convert current object to byte sequence")


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Removes null fields from current object before matching because there are cases where it's necessary. 


### Why?
Persistentvolumeclaimtemplates in StatefulSets are root objects and for example the CreationTimestamp field will not be set in it, but left empty, which will be null. This will result in an unnecessary diff, that we want to avoid, thus removing null fields from current.

### Additional context
The issue came up in the bank-vaults project.

- [x] Implementation tested

