### PR TITLE
fixing numeric pointer diffs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/googleapis/gnostic v0.3.0 // indirect
 	github.com/goph/emperror v0.17.2
 	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be
+	github.com/modern-go/reflect2 v1.0.1
 	github.com/pkg/errors v0.8.1
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect

--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,5 @@ require (
 	k8s.io/client-go v0.15.7
 	k8s.io/klog v0.4.0
 	k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6 // indirect
-	k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a // indirect
+	k8s.io/utils v0.0.0-20190809000727-6c36bc71fc4a
 )

--- a/integration_test.go
+++ b/integration_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 )
 
 func TestIntegration(t *testing.T) {
@@ -452,6 +453,33 @@ func TestIntegration(t *testing.T) {
 						},
 					},
 				},
+			}),
+		NewTestDiff("deployment does not match when replicas changes",
+			&appsv1.Deployment{
+				ObjectMeta: standardObjectMeta(),
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"a": "b",
+						},
+					},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metaWithLabels(map[string]string{
+							"a": "b",
+						}),
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name: "test-container", Image: "test-image",
+								},
+							},
+						},
+					},
+				},
+			}).
+			withLocalChange(func(i interface{}) {
+				pod := i.(*appsv1.Deployment)
+				pod.Spec.Replicas = pointer.Int32Ptr(0)
 			}),
 		NewTestMatch("hpa match",
 			&v2beta1.HorizontalPodAutoscaler{

--- a/main_test.go
+++ b/main_test.go
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 	if *integration {
 		err := testContext.Setup()
 		if err != nil {
-			panic("Failed to setup test namespace")
+			panic("Failed to setup test namespace: " + err.Error())
 		}
 	}
 	result := m.Run()

--- a/patch/annotation.go
+++ b/patch/annotation.go
@@ -15,7 +15,7 @@
 package patch
 
 import (
-	"encoding/json"
+	json "github.com/json-iterator/go"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/patch/deletenull.go
+++ b/patch/deletenull.go
@@ -15,12 +15,38 @@
 package patch
 
 import (
-	"encoding/json"
 	"reflect"
+	"unsafe"
 
 	"github.com/goph/emperror"
+	json "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
+
+func init() {
+	// k8s.io/apimachinery/pkg/util/intstr.IntOrString behaves really badly
+	// from JSON marshaling point of view, it can't be empty basically.
+	// So we need to override the defined marshaling behaviour and write nil
+	// instead of 0, because usually (in all observed cases) 0 means "not set"
+	// for IntOrStr types.
+	// To make this happen we need to pull in json-iterator and override the
+	// factory marshaling overrides.
+	json.RegisterTypeEncoderFunc("intstr.IntOrString",
+		func(ptr unsafe.Pointer, stream *json.Stream) {
+			i := (*intstr.IntOrString)(ptr)
+			if i.IntValue() == 0 {
+				stream.WriteNil()
+			} else {
+				stream.WriteInt(i.IntValue())
+			}
+		},
+		func(ptr unsafe.Pointer) bool {
+			i := (*intstr.IntOrString)(ptr)
+			return i.IntValue() == 0
+		},
+	)
+}
 
 func DeleteNullInJson(jsonBytes []byte) ([]byte, map[string]interface{}, error) {
 	var patchMap map[string]interface{}
@@ -115,6 +141,8 @@ func isZero(v reflect.Value) bool {
 	default:
 		z := reflect.Zero(v.Type())
 		return v.Interface() == z.Interface()
+	case reflect.Float64, reflect.Int64:
+		return false
 	case reflect.Func, reflect.Map, reflect.Slice:
 		return v.IsNil()
 	case reflect.Array:

--- a/patch/patch.go
+++ b/patch/patch.go
@@ -15,8 +15,8 @@
 package patch
 
 import (
-	"encoding/json"
 	"fmt"
+	json "github.com/json-iterator/go"
 
 	"github.com/goph/emperror"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
- added test case for numeric pointer diffs, they didn't work previously (showed no diff)
- fixed the above issue with some number handling and JSON marshaling changes and

### Why?
`k8s.io/apimachinery/pkg/util/intstr.IntOrString` behaves really badly from JSON marshaling point of view, it can't be empty basically. So we need to override the defined marshaling behaviour and write nil
instead of 0, because usually (in all observed cases) 0 means "not set" for IntOrStr types. To make this happen we need to pull in json-iterator and override the factory marshaling overrides.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


