### PR TITLE
Use currentObject instead of desired to calculate lookupMetaPatch

### DIFF
--- a/patch/patch.go
+++ b/patch/patch.go
@@ -75,7 +75,7 @@ func (p *PatchMaker) Calculate(currentObject, modifiedObject runtime.Object, opt
 
 	switch currentObject.(type) {
 	default:
-		lookupPatchMeta, err := strategicpatch.NewPatchMetaFromStruct(modifiedObject)
+		lookupPatchMeta, err := strategicpatch.NewPatchMetaFromStruct(currentObject)
 		if err != nil {
 			return nil, emperror.WrapWith(err, "Failed to lookup patch meta", "current object", currentObject)
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Use currentObject instead of desired to calculate lookupMetaPatch.
This causes problem when using objectmatcher with unstructured type.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
