### PR TITLE
Fix intOrString for strings

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -305,6 +305,46 @@ func TestIntegration(t *testing.T) {
 					Type: v1.ServiceTypeLoadBalancer,
 				},
 			}),
+		NewTestDiff("service with named port diffs with existing",
+			&v1.Service{
+				ObjectMeta: standardObjectMeta(),
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   v1.ProtocolTCP,
+							Port:       80,
+							TargetPort: intstr.FromString("http"),
+						},
+					},
+					Selector: map[string]string{
+						"app": "test",
+					},
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			}).
+			withLocalChange(func(a interface{}) {
+				b := a.(*v1.Service)
+				b.Spec.Ports[0].TargetPort = intstr.FromString("https")
+			}),
+		NewTestMatch("service with named port matches with original",
+			&v1.Service{
+				ObjectMeta: standardObjectMeta(),
+				Spec: v1.ServiceSpec{
+					Ports: []v1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   v1.ProtocolTCP,
+							Port:       80,
+							TargetPort: intstr.FromString("http"),
+						},
+					},
+					Selector: map[string]string{
+						"app": "test",
+					},
+					Type: v1.ServiceTypeLoadBalancer,
+				},
+			}),
 		NewTestMatch("service matches with original even if defaults are not set",
 			&v1.Service{
 				ObjectMeta: standardObjectMeta(),

--- a/patch/deletenull.go
+++ b/patch/deletenull.go
@@ -72,14 +72,18 @@ func init() {
 		func(ptr unsafe.Pointer, stream *json.Stream) {
 			i := (*intstr.IntOrString)(ptr)
 			if i.IntValue() == 0 {
-				stream.WriteNil()
+				if i.StrVal != "" && i.StrVal != "0" {
+					stream.WriteString(i.StrVal)
+				} else {
+					stream.WriteNil()
+				}
 			} else {
 				stream.WriteInt(i.IntValue())
 			}
 		},
 		func(ptr unsafe.Pointer) bool {
 			i := (*intstr.IntOrString)(ptr)
-			return i.IntValue() == 0
+			return i.IntValue() == 0 && (i.StrVal == "" || i.StrVal == "0")
 		},
 	)
 }


### PR DESCRIPTION

### What's in this PR?
Fixes intOrString matching for named values. 


### Why?
Current implementation worked well for integers but not for named values where it removed the value from both sides, so it was unable to detect a diff.

It came out where unstructured was used as the desired object's type, thus the named port was not removed.
