### PR TITLE
base64 encode last-applied annotation

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -223,7 +223,7 @@ func TestIntegration(t *testing.T) {
 				pod := i.(*v1.Pod)
 				pod.Spec.Affinity = nil
 			}),
-		NewTestMatch("Secret matches with original",
+		NewTestMatch("secret matches with original",
 			&v1.Secret{
 				ObjectMeta: standardObjectMeta(),
 				StringData: map[string]string{

--- a/integration_test.go
+++ b/integration_test.go
@@ -226,8 +226,8 @@ func TestIntegration(t *testing.T) {
 		NewTestMatch("secret matches with original",
 			&v1.Secret{
 				ObjectMeta: standardObjectMeta(),
-				StringData: map[string]string{
-					"key": "secretValue",
+				Data: map[string][]byte{
+					"key": []byte("secretValue"),
 				},
 			}),
 		NewTestMatch("serviceaccount matches with original",

--- a/integration_test.go
+++ b/integration_test.go
@@ -223,6 +223,13 @@ func TestIntegration(t *testing.T) {
 				pod := i.(*v1.Pod)
 				pod.Spec.Affinity = nil
 			}),
+		NewTestMatch("Secret matches with original",
+			&v1.Secret{
+				ObjectMeta: standardObjectMeta(),
+				StringData: map[string]string{
+					"key": "secretValue",
+				},
+			}),
 		NewTestMatch("serviceaccount matches with original",
 			&v1.ServiceAccount{
 				ObjectMeta: standardObjectMeta(),

--- a/main_test.go
+++ b/main_test.go
@@ -280,6 +280,17 @@ func testMatchOnObject(testItem *TestItem) error {
 				log.Printf("Failed to remove object %s", existing.GetName())
 			}
 		}()
+	case *v1.Secret:
+		existing, err = testContext.Client.CoreV1().Secrets(newObject.GetNamespace()).Create(newObject.(*v1.Secret))
+		if err != nil {
+			return emperror.WrapWith(err, "failed to create object", "object", newObject)
+		}
+		defer func() {
+			err = testContext.Client.CoreV1().Secrets(newObject.GetNamespace()).Delete(existing.GetName(), deleteOptions)
+			if err != nil {
+				log.Printf("Failed to remove object %s", existing.GetName())
+			}
+		}()
 	case *v1beta1.CustomResourceDefinition:
 		existing, err = testContext.ExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(newObject.(*v1beta1.CustomResourceDefinition))
 		if err != nil {

--- a/patch/annotation.go
+++ b/patch/annotation.go
@@ -56,6 +56,7 @@ func (a *Annotator) GetOriginalConfiguration(obj runtime.Object) ([]byte, error)
 		return nil, nil
 	}
 
+	// Try to base64 decode, and fallback to non-base64 encoded content for backwards compatibility.
 	if decoded, err := base64.StdEncoding.DecodeString(original); err == nil {
 		return decoded, nil
 	}


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Base64 encoding the last-applied annotation, so no "secret" data can be easily read out when displaying the object.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
`Squash and merge`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
