### PR TITLE
fix(patch): use ordered keys when marshalling json

### DIFF
--- a/patch/annotation.go
+++ b/patch/annotation.go
@@ -115,7 +115,7 @@ func (a *Annotator) GetModifiedConfiguration(obj runtime.Object, annotate bool) 
 		a.metadataAccessor.SetAnnotations(obj, nil)
 	}
 
-	modified, err = json.Marshal(obj)
+	modified, err = json.ConfigCompatibleWithStandardLibrary.Marshal(obj)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (a *Annotator) GetModifiedConfiguration(obj runtime.Object, annotate bool) 
 			return nil, err
 		}
 
-		modified, err = json.Marshal(obj)
+		modified, err = json.ConfigCompatibleWithStandardLibrary.Marshal(obj)
 		if err != nil {
 			return nil, err
 		}

--- a/patch/deletenull.go
+++ b/patch/deletenull.go
@@ -101,7 +101,7 @@ func DeleteNullInJson(jsonBytes []byte) ([]byte, map[string]interface{}, error) 
 		return nil, nil, emperror.Wrap(err, "could not delete null values from patch map")
 	}
 
-	o, err := json.Marshal(filteredMap)
+	o, err := json.ConfigCompatibleWithStandardLibrary.Marshal(filteredMap)
 	if err != nil {
 		return nil, nil, emperror.Wrap(err, "could not marshal filtered patch map")
 	}
@@ -183,7 +183,7 @@ func deleteStatusField(obj []byte) ([]byte, error) {
 		return []byte{}, emperror.Wrap(err, "could not unmarshal byte sequence")
 	}
 	delete(objectMap, "status")
-	obj, err = json.Marshal(objectMap)
+	obj, err = json.ConfigCompatibleWithStandardLibrary.Marshal(objectMap)
 	if err != nil {
 		return []byte{}, emperror.Wrap(err, "could not marshal byte sequence")
 	}
@@ -206,7 +206,7 @@ func deleteVolumeClaimTemplateFields(obj []byte) ([]byte, error) {
 		}
 	}
 
-	obj, err = json.Marshal(sts)
+	obj, err = json.ConfigCompatibleWithStandardLibrary.Marshal(sts)
 	if err != nil {
 		return []byte{}, emperror.Wrap(err, "could not marshal byte sequence")
 	}

--- a/patch/patch.go
+++ b/patch/patch.go
@@ -39,12 +39,12 @@ func NewPatchMaker(annotator *Annotator) *PatchMaker {
 }
 
 func (p *PatchMaker) Calculate(currentObject, modifiedObject runtime.Object, opts ...CalculateOption) (*PatchResult, error) {
-	current, err := json.Marshal(currentObject)
+	current, err := json.ConfigCompatibleWithStandardLibrary.Marshal(currentObject)
 	if err != nil {
 		return nil, emperror.Wrap(err, "Failed to convert current object to byte sequence")
 	}
 
-	modified, err := json.Marshal(modifiedObject)
+	modified, err := json.ConfigCompatibleWithStandardLibrary.Marshal(modifiedObject)
 	if err != nil {
 		return nil, emperror.Wrap(err, "Failed to convert current object to byte sequence")
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #24 
| License         | Apache 2.0


### What's in this PR?
Change the JSON marshalling method to sort the keys.


### Why?
Infinite reconcile loops caused by different annotations because of random order JSON representation.


### Additional context
I tested the implementation by forking this repo and using it in my operator.


### Checklist

- [X] Implementation tested
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)

### To Do
- [ ] Run automated tests if needed?
- [ ] Handle other places where this modification is required? 
