### PR TITLE
Fix invalid json error which happens when the annotation is not zippe…

### DIFF
--- a/patch/annotation.go
+++ b/patch/annotation.go
@@ -65,6 +65,7 @@ func (a *Annotator) GetOriginalConfiguration(obj runtime.Object) ([]byte, error)
 		if http.DetectContentType(decoded) == "application/zip" {
 			return unZipAnnotation(decoded)
 		}
+		return decoded, nil
 	}
 
 	return []byte(original), nil


### PR DESCRIPTION
…d but base64 encoded

| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes an invalid JSON error which happened when the annotation is base 64 encoded but not zipped.
We returned the original base64 encoded value instead of the decoded one.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
