### PR TITLE
Fix IgnoreVolumeClaimTemplateTypeMetaAndStatus 

### DIFF
--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -190,6 +190,7 @@ func testMatchOnObject(testItem *TestItem) error {
 	var err error
 	opts := []patch.CalculateOption{
 		patch.IgnoreStatusFields(),
+		patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(),
 	}
 
 	newObject := testItem.object
@@ -403,7 +404,6 @@ func testMatchOnObject(testItem *TestItem) error {
 			}
 		}()
 	case *appsv1.StatefulSet:
-		opts = append(opts, patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus())
 		existing, err = testContext.Client.AppsV1().StatefulSets(newObject.GetNamespace()).Create(context.Background(), newObject.(*appsv1.StatefulSet), metav1.CreateOptions{})
 		if err != nil {
 			return errors.WrapWithDetails(err, "failed to create object", "object", newObject)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fixes the ignore calculation that handles PVC templates in statefulsets correctly so that it can be used with all resource types and with K8S 1.17 and up.

### Why?
The current ignore calculation cannot be used for all resource types.

