### PR TITLE
IgnoreVolumeClaimTemplateFields: ignore volumeMode

### DIFF
--- a/patch/deletenull.go
+++ b/patch/deletenull.go
@@ -237,6 +237,10 @@ func deleteVolumeClaimTemplateFields(obj []byte) ([]byte, error) {
 							vct["status"] = map[string]string{
 								"phase": "Pending",
 							}
+
+							if vctSpec, ok := vct["spec"].(map[string]interface{}); ok {
+								delete(vctSpec, "volumeMode")
+							}
 						}
 					}
 				}


### PR DESCRIPTION
It seems volumeMode is set server-side in certain cases (e.g. k3s sets
it to 'Filesystem'), which causes unwanted diffs. Deleting the field
from both current and modified effectively ignores this field.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
IgnoreVolumeClaimTemplateTypeMetaAndStatus now ignores spec.volumeClaimTemplates[].spec.volumeMode by removing it from both current and modified.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
I got "strange" diffs. It turned out, that this lib does not ignore spec.volumeClaimTemplates[].spec.volumeMode, which is set after Creating a sts. I am working with k3s at this time, so it may be a case that happens only with k3s or in certain edge cases.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
I'm using k3s with a very standard setup (just ran their script on the landing page)


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested (**manually only, will add automated test if somebody can confirm this change makes sense!**)
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Add automated test, if maintainers are interested in this PR.
