### PR TITLE
bugfix: make it not drop default values in objects

### DIFF
--- a/patch/deletenull.go
+++ b/patch/deletenull.go
@@ -127,7 +127,7 @@ func deleteNullInObj(m map[string]interface{}) (map[string]interface{}, error) {
 	filteredMap := make(map[string]interface{})
 
 	for key, val := range m {
-		if val == nil || isZero(reflect.ValueOf(val)) {
+		if val == nil || (isZero(reflect.ValueOf(val)) && key != "default") {
 			continue
 		}
 		switch typedVal := val.(type) {


### PR DESCRIPTION
If a change in an object only includes changes to
defaults, this library will strip the defaults
values away (through deleteNull function call) and then create noop patch through the 3 way merge (because it will contain the updated prev version annotation) that can't be applied on recent versions of kubernetes

| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
